### PR TITLE
Add character sheet popup on double click

### DIFF
--- a/scripts/gameplay/Battle.gd
+++ b/scripts/gameplay/Battle.gd
@@ -1,6 +1,7 @@
 extends Node
 class_name Battle
 const PF := preload("res://scripts/grid/Pathfinder3D.gd")
+const CharacterSheet := preload("res://ui/CharacterSheet.gd")
 
 # --- tuning ---
 const MELEE_RANGE := 1
@@ -19,6 +20,7 @@ var turn_order: Array[StringName] = []
 var active_index: int = 0
 
 var hover_marker: MeshInstance3D
+var _char_sheet: CharacterSheet
 
 # input mode: "move" or "cast_fb"
 var _mode: StringName = "move"
@@ -132,6 +134,13 @@ func _unhandled_input(event: InputEvent) -> void:
 			return
 
 	if event is InputEventMouseButton and event.pressed:
+		if event.button_index == MOUSE_BUTTON_LEFT and event.double_click:
+			var t_dc: Vector2i = _mouse_tile()
+			if t_dc != null:
+				var id_dc := _entity_id_at_tile(t_dc)
+				if id_dc != "" and entities.has(id_dc):
+					_open_character_sheet(entities[id_dc])
+			return
 		# Right click = melee try
 		if event.button_index == MOUSE_BUTTON_RIGHT:
 			var t_rc: Vector2i = _mouse_tile()
@@ -421,6 +430,18 @@ func _entity_id_at_tile(t: Vector2i) -> StringName:
 		if entities[id].tile == t:
 			return id
 	return StringName("")
+
+func _open_character_sheet(e: Entity3D) -> void:
+	if not is_instance_valid(_char_sheet):
+		_char_sheet = CharacterSheet.new()
+		var ui := get_parent().get_node("UI") if get_parent().has_node("UI") else null
+		if ui:
+			ui.add_child(_char_sheet)
+	_char_sheet.set_entity(e)
+	if _char_sheet.has_method("popup_centered"):
+		_char_sheet.popup_centered()
+	else:
+		_char_sheet.visible = true
 
 func _manhattan(a: Vector2i, b: Vector2i) -> int:
 	return abs(a.x - b.x) + abs(a.y - b.y)

--- a/ui/CharacterSheet.gd
+++ b/ui/CharacterSheet.gd
@@ -1,0 +1,36 @@
+extends Window
+class_name CharacterSheet
+
+var _entity: Entity3D
+var _name_label: Label
+var _hp_label: Label
+var _mp_label: Label
+var _status_label: Label
+
+func _ready() -> void:
+        title = "Character Sheet"
+        size = Vector2i(240, 160)
+        var vb := VBoxContainer.new()
+        vb.anchor_right = 1.0
+        vb.anchor_bottom = 1.0
+        vb.offset_left = 10
+        vb.offset_top = 10
+        vb.offset_right = -10
+        vb.offset_bottom = -10
+        add_child(vb)
+        _name_label = Label.new()
+        vb.add_child(_name_label)
+        _hp_label = Label.new()
+        vb.add_child(_hp_label)
+        _mp_label = Label.new()
+        vb.add_child(_mp_label)
+        _status_label = Label.new()
+        vb.add_child(_status_label)
+
+func set_entity(e: Entity3D) -> void:
+        _entity = e
+        title = str(e.entity_id)
+        _name_label.text = "Name: %s" % e.entity_id
+        _hp_label.text = "HP: %d / %d" % [e.hp, e.max_hp]
+        _mp_label.text = "MP: %d" % e.move_points
+        _status_label.text = "Statuses: %s" % ", ".join(e.status_effects)

--- a/ui/CharacterSheet.gd.uid
+++ b/ui/CharacterSheet.gd.uid
@@ -1,0 +1,1 @@
+uid://6hd6u7n12lb5p


### PR DESCRIPTION
## Summary
- Implement CharacterSheet UI to display entity name, HP, MP and statuses
- Load and show the character sheet when double-clicking on a unit in battle

## Testing
- `godot --headless --check scenes/Game.tscn` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab75f8f18c8324bcbce4935f11a066